### PR TITLE
fix: strict types

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        deno: ["v0.33.0", "v0.32.0", "v0.31.0"]
+        deno: ["v0.35.0", "v0.34.0", "v0.33.0"]
     name: deno ${{ matrix.deno }} sample
     steps:
       - uses: actions/checkout@master
@@ -23,4 +23,4 @@ jobs:
         uses: denolib/setup-deno@v1
         with:
           deno-version: ${{ matrix.deno }}
-      - run: deno test **/*_test.ts
+      - run: deno test

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        deno: ["v0.35.0", "v0.34.0", "v0.33.0"]
+        deno: ["v0.35.0", "v0.34.0"]
     name: deno ${{ matrix.deno }} sample
     steps:
       - uses: actions/checkout@master

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - added better typings for places where types could be ambigous
 - migrated to `deno test`
 - bumped `std` version to `v0.33.0`
+- fixes `prop` failing TS checks when being used
 
 ### Removed
 

--- a/README.md
+++ b/README.md
@@ -564,6 +564,6 @@ If you want to contribute to Denofun:
 
 1. Clone this repository.
 2. Make sure you have Deno installed.
-3. You can run tests with `deno test **/*_test.ts` (or `deno test ./test` if [#4002](https://github.com/denoland/deno/pull/4002) is fixed. :)).
+3. You can run tests with `deno test`.
 
 Thanks!

--- a/lib/curry.ts
+++ b/lib/curry.ts
@@ -10,7 +10,7 @@ export default function curry(fn: (...args: any[]) => any) {
             return fn(...args);
         }
 
-        return function(a) {
+        return function(a: any) {
             return curried(...[...args, a]);
         }
     }

--- a/lib/find.ts
+++ b/lib/find.ts
@@ -4,6 +4,6 @@
  * @param xs an array of elements to be searched
  * @returns first element that returned true
  */
-export default function find<A>(fn: (x: A) => boolean, xs: A[]): A {
+export default function find<A>(fn: (x: A) => boolean, xs: A[]): A | undefined {
     return xs.find(fn);
 }

--- a/lib/group_by.ts
+++ b/lib/group_by.ts
@@ -5,7 +5,7 @@
  * @returns a object with elements grouped by preferred key
  */
 export default function groupBy<A>(fn: (x: A) => any, arr: A[]) {
-    const result = {};
+    const result: { [key: string]: any } = {};
     for (let i = 0; i < arr.length; i++) {
         const item = arr[i];
         const key = fn(item);

--- a/lib/omit.ts
+++ b/lib/omit.ts
@@ -4,8 +4,8 @@
  * @param object object to be copied
  * @returns an object without specified keys
  */
-export default function omit(keys: string[], object: object): object {
-    let target = {};
+export default function omit(keys: string[], object: { [key: string]: any }): object {
+    let target: { [key: string]: any } = {};
 
     for (let i in object) {
         if (keys.indexOf(i) >= 0) continue;

--- a/lib/pick.ts
+++ b/lib/pick.ts
@@ -4,8 +4,8 @@
  * @param object object to be copied
  * @returns an object with specified keys only
  */
-export default function pick(keys: string[], object: object): object {
-    let target = {};
+export default function pick(keys: string[], object: { [key: string]: any }): object {
+    let target: { [key: string]: any } = {};
 
     for (let i of keys) {
         if (i in object) {

--- a/lib/pipe.ts
+++ b/lib/pipe.ts
@@ -3,6 +3,6 @@
  * @param fns a list of functions to pipe
  * @returns a new function composed from the provided functions
  */
-export default function pipe(...fns) {
+export default function pipe(...fns: ((...args: any[]) => any)[]) {
     return fns.reduce((f, g) => (...args) => g(f(...args)));
 }

--- a/lib/pluck.ts
+++ b/lib/pluck.ts
@@ -4,7 +4,7 @@
  * @param xs input object
  * @returns the list of values for a given key from each of the objects
  */
-export default function pluck(key: string, xs: object[]): any {
+export default function pluck(key: string, xs: Array<{ [key: string]: any }>): any {
     const result = [];
     for (const x in xs) {
         if (xs[x].hasOwnProperty(key)) {

--- a/lib/prop.ts
+++ b/lib/prop.ts
@@ -4,6 +4,6 @@
  * @param obj input object
  * @returns value of object's `key` property
  */
-export default function prop(key: string, obj: object): any {
+export default function prop(key: string, obj: { [key: string]: any }): any {
     return obj[key];
 }

--- a/lib/reverse.ts
+++ b/lib/reverse.ts
@@ -5,7 +5,7 @@
  */
 export default function reverse(x: string): string;
 export default function reverse<A>(x: A[]): A[];
-export default function reverse<A>(x: string | A[]): string | A[] {
+export default function reverse<A>(x: string | A[]): A[] | string | undefined {
     if (Array.isArray(x)) {
         return x.reverse();
     }

--- a/test/compose_test.ts
+++ b/test/compose_test.ts
@@ -2,15 +2,15 @@ import { assertEquals } from "https://deno.land/std@v0.33.0/testing/asserts.ts"
 
 import compose from '../lib/compose.ts';
 
-function add5(n) {
+function add5(n: number) {
     return n + 5;
 }
 
-function mul2(n) {
+function mul2(n: number) {
     return n * 2;
 }
 
-function sub(a, b) {
+function sub(a: number, b: number) {
     return a - b;
 }
 

--- a/test/curry_test.ts
+++ b/test/curry_test.ts
@@ -2,7 +2,7 @@ import { assertEquals } from "https://deno.land/std@v0.33.0/testing/asserts.ts"
 
 import curry from '../lib/curry.ts';
 
-function add(a, b) {
+function add(a: number, b: number) {
     return a + b;
 }
 

--- a/test/filter_test.ts
+++ b/test/filter_test.ts
@@ -2,7 +2,7 @@ import { assertEquals } from "https://deno.land/std@v0.33.0/testing/asserts.ts"
 
 import filter from '../lib/filter.ts';
 
-function isLessThan5(n) {
+function isLessThan5(n: number) {
     return n < 5;
 }
 

--- a/test/find_test.ts
+++ b/test/find_test.ts
@@ -2,7 +2,7 @@ import { assertEquals } from "https://deno.land/std@v0.33.0/testing/asserts.ts"
 
 import find from '../lib/find.ts';
 
-function findToyota(car) {
+function findToyota(car: { make: string; }) {
     return car.make === 'Toyota';
 }
 

--- a/test/map_test.ts
+++ b/test/map_test.ts
@@ -2,7 +2,7 @@ import { assertEquals } from "https://deno.land/std@v0.33.0/testing/asserts.ts"
 
 import map from '../lib/map.ts';
 
-function double(n) {
+function double(n: number) {
     return n * 2;
 }
 

--- a/test/pipe_test.ts
+++ b/test/pipe_test.ts
@@ -2,15 +2,15 @@ import { assertEquals } from "https://deno.land/std@v0.33.0/testing/asserts.ts"
 
 import pipe from '../lib/pipe.ts';
 
-function add5(n) {
+function add5(n: number) {
     return n + 5;
 }
 
-function mul2(n) {
+function mul2(n: number) {
     return n * 2;
 }
 
-function sub(a, b) {
+function sub(a: number, b: number) {
     return a - b;
 }
 

--- a/test/reduce_test.ts
+++ b/test/reduce_test.ts
@@ -2,7 +2,7 @@ import { assertEquals } from "https://deno.land/std@v0.33.0/testing/asserts.ts"
 
 import reduce from '../lib/reduce.ts';
 
-function add(a, b) {
+function add(a: number, b: number) {
     return a + b;
 }
 

--- a/test/sort_test.ts
+++ b/test/sort_test.ts
@@ -14,6 +14,8 @@ function sortNumbers (a: number, b: number) {
     if (a < b) {
         return -1;
     }
+
+    return 0;
 }
 
 function sortStringsByLength (a: string, b: string) {
@@ -28,6 +30,8 @@ function sortStringsByLength (a: string, b: string) {
     if (a.length < b.length) {
         return -1;
     }
+
+    return 0;
 }
 
 Deno.test({


### PR DESCRIPTION
At some point Deno introduced strict typing that was not caught by our tests. It should work fine now.﻿
