### PR TITLE
Fix some breaking issues when using latest version of Deno.

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -15,12 +15,12 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        deno: ["v0.35.0", "v0.34.0"]
+        deno: [0.42.0]
     name: deno ${{ matrix.deno }} sample
     steps:
       - uses: actions/checkout@master
       - name: setup deno
-        uses: denolib/setup-deno@v1
+        uses: denolib/setup-deno@v1.3.0
         with:
           deno-version: ${{ matrix.deno }}
       - run: deno test

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,8 +19,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - locked all std dependencies (`std/testing`) to `v0.32.0`
 - added better typings for places where types could be ambigous
 - migrated to `deno test`
-- bumped `std` version to `v0.33.0`
+- bumped `std` version to `v0.42.0`
 - fixes `prop` failing TS checks when being used
+- account for removal of `Deno.symbols` namespace
 
 ### Removed
 

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -9,3 +9,5 @@ Contributors to denofun project (sorted alphabetically).
     - added maybe and either
 - **[Hoàng Văn Khải](https://github.com/KSXGitHub)**
     - added partition function
+- **[Jake McCloskey](https://github.com/jakemccloskey)**
+    - fixed some issues to to changes in Deno

--- a/lib/either/Either.ts
+++ b/lib/either/Either.ts
@@ -29,5 +29,5 @@ export default interface Either<Left, Right> {
 
     toJSON(): Left | Right;
     toString(): string;
-    [Deno.symbols.customInspect](): string;
+    [Deno.customInspect](): string;
 }

--- a/lib/either/error.ts
+++ b/lib/either/error.ts
@@ -54,7 +54,7 @@ export default function error<Left, Right>(value: Right): Either<Left, Right> {
         toString() {
             return String(value);
         },
-        [Deno.symbols.customInspect]() {
+        [Deno.customInspect]() {
             return `error(${value})`;
         }
     }

--- a/lib/either/json_error.ts
+++ b/lib/either/json_error.ts
@@ -62,7 +62,7 @@ export default function jsonError<Left, Right>(value: Right): Either<Left, Right
         toString() {
             return String(value);
         },
-        [Deno.symbols.customInspect]() {
+        [Deno.customInspect]() {
             return `jsonError(${value})`;
         }
     }

--- a/lib/either/left.ts
+++ b/lib/either/left.ts
@@ -54,7 +54,7 @@ export default function left<Left, Right>(value: Left): Either<Left, Right> {
         toString() {
             return String(value);
         },
-        [Deno.symbols.customInspect]() {
+        [Deno.customInspect]() {
             return `left(${value})`;
         }
     }

--- a/lib/either/right.ts
+++ b/lib/either/right.ts
@@ -54,7 +54,7 @@ export default function right<Left, Right>(value: Right): Either<Left, Right> {
         toString() {
             return String(value);
         },
-        [Deno.symbols.customInspect]() {
+        [Deno.customInspect]() {
             return `right(${value})`;
         }
     }

--- a/lib/maybe.ts
+++ b/lib/maybe.ts
@@ -14,7 +14,7 @@ export interface Maybe<T> extends Iterable<T> {
 
     toJSON(): T | undefined;
     toString(): string;
-    [Deno.symbols.customInspect](): string;
+    [Deno.customInspect](): string;
 }
 
 // nothing is a function to avoid side effects due to mutations of a global object
@@ -48,7 +48,7 @@ function nothing<T>(): Maybe<T> {
             return "";
         },
         *[Symbol.iterator]() {},
-        [Deno.symbols.customInspect]() {
+        [Deno.customInspect]() {
             return "nothing()";
         }
     }
@@ -91,7 +91,7 @@ function just<T>(value: T): Maybe<T> {
         *[Symbol.iterator]() {
             yield value;
         },
-        [Deno.symbols.customInspect]() {
+        [Deno.customInspect]() {
             return `just(${value})`;
         }
     }

--- a/test/compose_test.ts
+++ b/test/compose_test.ts
@@ -1,4 +1,4 @@
-import { assertEquals } from "https://deno.land/std@v0.33.0/testing/asserts.ts"
+import { assertEquals } from "https://deno.land/std@v0.42.0/testing/asserts.ts"
 
 import compose from '../lib/compose.ts';
 

--- a/test/concat_test.ts
+++ b/test/concat_test.ts
@@ -1,4 +1,4 @@
-import { assertEquals } from "https://deno.land/std@v0.33.0/testing/asserts.ts"
+import { assertEquals } from "https://deno.land/std@v0.42.0/testing/asserts.ts"
 
 import concat from '../lib/concat.ts';
 

--- a/test/curry_test.ts
+++ b/test/curry_test.ts
@@ -1,4 +1,4 @@
-import { assertEquals } from "https://deno.land/std@v0.33.0/testing/asserts.ts"
+import { assertEquals } from "https://deno.land/std@v0.42.0/testing/asserts.ts"
 
 import curry from '../lib/curry.ts';
 

--- a/test/either_test.ts
+++ b/test/either_test.ts
@@ -1,4 +1,4 @@
-import { assertEquals, assertThrows, assertThrowsAsync, assert } from "https://deno.land/std@v0.33.0/testing/asserts.ts";
+import { assertEquals, assertThrows, assertThrowsAsync, assert } from "https://deno.land/std@v0.42.0/testing/asserts.ts";
 
 import left from '../lib/either/left.ts';
 import right from '../lib/either/right.ts';

--- a/test/equals_test.ts
+++ b/test/equals_test.ts
@@ -1,4 +1,4 @@
-import { assertEquals } from "https://deno.land/std@v0.33.0/testing/asserts.ts"
+import { assertEquals } from "https://deno.land/std@v0.42.0/testing/asserts.ts"
 
 import equals from '../lib/equals.ts';
 

--- a/test/filter_test.ts
+++ b/test/filter_test.ts
@@ -1,4 +1,4 @@
-import { assertEquals } from "https://deno.land/std@v0.33.0/testing/asserts.ts"
+import { assertEquals } from "https://deno.land/std@v0.42.0/testing/asserts.ts"
 
 import filter from '../lib/filter.ts';
 

--- a/test/find_test.ts
+++ b/test/find_test.ts
@@ -1,4 +1,4 @@
-import { assertEquals } from "https://deno.land/std@v0.33.0/testing/asserts.ts"
+import { assertEquals } from "https://deno.land/std@v0.42.0/testing/asserts.ts"
 
 import find from '../lib/find.ts';
 

--- a/test/flatten_test.ts
+++ b/test/flatten_test.ts
@@ -1,4 +1,4 @@
-import { assertEquals } from "https://deno.land/std@v0.33.0/testing/asserts.ts"
+import { assertEquals } from "https://deno.land/std@v0.42.0/testing/asserts.ts"
 
 import flatten from '../lib/flatten.ts';
 

--- a/test/group_by_test.ts
+++ b/test/group_by_test.ts
@@ -1,4 +1,4 @@
-import { assertEquals } from "https://deno.land/std@v0.33.0/testing/asserts.ts"
+import { assertEquals } from "https://deno.land/std@v0.42.0/testing/asserts.ts"
 
 import groupBy from '../lib/group_by.ts';
 

--- a/test/has_test.ts
+++ b/test/has_test.ts
@@ -1,4 +1,4 @@
-import { assertEquals } from "https://deno.land/std@v0.33.0/testing/asserts.ts"
+import { assertEquals } from "https://deno.land/std@v0.42.0/testing/asserts.ts"
 
 import has from '../lib/has.ts';
 

--- a/test/head_test.ts
+++ b/test/head_test.ts
@@ -1,4 +1,4 @@
-import { assertEquals } from "https://deno.land/std@v0.33.0/testing/asserts.ts"
+import { assertEquals } from "https://deno.land/std@v0.42.0/testing/asserts.ts"
 
 import head from '../lib/head.ts';
 

--- a/test/identity_test.ts
+++ b/test/identity_test.ts
@@ -1,4 +1,4 @@
-import { assertEquals } from "https://deno.land/std@v0.33.0/testing/asserts.ts"
+import { assertEquals } from "https://deno.land/std@v0.42.0/testing/asserts.ts"
 
 import identity from '../lib/identity.ts';
 

--- a/test/includes_test.ts
+++ b/test/includes_test.ts
@@ -1,4 +1,4 @@
-import { assertEquals } from "https://deno.land/std@v0.33.0/testing/asserts.ts"
+import { assertEquals } from "https://deno.land/std@v0.42.0/testing/asserts.ts"
 
 import includes from "../lib/includes.ts";
 

--- a/test/keys_test.ts
+++ b/test/keys_test.ts
@@ -1,4 +1,4 @@
-import { assertEquals } from "https://deno.land/std@v0.33.0/testing/asserts.ts"
+import { assertEquals } from "https://deno.land/std@v0.42.0/testing/asserts.ts"
 
 import keys from '../lib/keys.ts';
 

--- a/test/last_test.ts
+++ b/test/last_test.ts
@@ -1,4 +1,4 @@
-import { assertEquals } from "https://deno.land/std@v0.33.0/testing/asserts.ts"
+import { assertEquals } from "https://deno.land/std@v0.42.0/testing/asserts.ts"
 
 import last from '../lib/last.ts';
 

--- a/test/map_test.ts
+++ b/test/map_test.ts
@@ -1,4 +1,4 @@
-import { assertEquals } from "https://deno.land/std@v0.33.0/testing/asserts.ts"
+import { assertEquals } from "https://deno.land/std@v0.42.0/testing/asserts.ts"
 
 import map from '../lib/map.ts';
 

--- a/test/maybe_test.ts
+++ b/test/maybe_test.ts
@@ -1,5 +1,5 @@
 
-import { assertEquals } from "https://deno.land/std@v0.33.0/testing/asserts.ts"
+import { assertEquals } from "https://deno.land/std@v0.42.0/testing/asserts.ts"
 
 import maybe, { mapMaybe } from '../lib/maybe.ts';
 

--- a/test/memoize_test.ts
+++ b/test/memoize_test.ts
@@ -1,4 +1,4 @@
-import { assertEquals } from "https://deno.land/std@v0.33.0/testing/asserts.ts";
+import { assertEquals } from "https://deno.land/std@v0.42.0/testing/asserts.ts";
 
 import memoize from '../lib/memoize.ts';
 

--- a/test/nth_test.ts
+++ b/test/nth_test.ts
@@ -1,4 +1,4 @@
-import { assertEquals } from "https://deno.land/std@v0.33.0/testing/asserts.ts"
+import { assertEquals } from "https://deno.land/std@v0.42.0/testing/asserts.ts"
 
 import nth from '../lib/nth.ts';
 

--- a/test/omit_test.ts
+++ b/test/omit_test.ts
@@ -1,4 +1,4 @@
-import { assertEquals } from "https://deno.land/std@v0.33.0/testing/asserts.ts"
+import { assertEquals } from "https://deno.land/std@v0.42.0/testing/asserts.ts"
 
 import omit from '../lib/omit.ts';
 

--- a/test/partition_test.ts
+++ b/test/partition_test.ts
@@ -1,4 +1,4 @@
-import { assertEquals } from "https://deno.land/std@v0.33.0/testing/asserts.ts";
+import { assertEquals } from "https://deno.land/std@v0.42.0/testing/asserts.ts";
 import partition from "../lib/partition.ts";
 
 Deno.test({

--- a/test/pick_test.ts
+++ b/test/pick_test.ts
@@ -1,4 +1,4 @@
-import { assertEquals } from "https://deno.land/std@v0.33.0/testing/asserts.ts"
+import { assertEquals } from "https://deno.land/std@v0.42.0/testing/asserts.ts"
 
 import pick from "../lib/pick.ts";
 

--- a/test/pipe_test.ts
+++ b/test/pipe_test.ts
@@ -1,4 +1,4 @@
-import { assertEquals } from "https://deno.land/std@v0.33.0/testing/asserts.ts"
+import { assertEquals } from "https://deno.land/std@v0.42.0/testing/asserts.ts"
 
 import pipe from '../lib/pipe.ts';
 

--- a/test/pluck_test.ts
+++ b/test/pluck_test.ts
@@ -1,4 +1,4 @@
-import { assertEquals } from "https://deno.land/std@v0.33.0/testing/asserts.ts"
+import { assertEquals } from "https://deno.land/std@v0.42.0/testing/asserts.ts"
 
 import pluck from "../lib/pluck.ts";
 

--- a/test/prop_test.ts
+++ b/test/prop_test.ts
@@ -1,4 +1,4 @@
-import { assertEquals } from "https://deno.land/std@v0.33.0/testing/asserts.ts"
+import { assertEquals } from "https://deno.land/std@v0.42.0/testing/asserts.ts"
 
 import prop from '../lib/prop.ts';
 

--- a/test/reduce_test.ts
+++ b/test/reduce_test.ts
@@ -1,4 +1,4 @@
-import { assertEquals } from "https://deno.land/std@v0.33.0/testing/asserts.ts"
+import { assertEquals } from "https://deno.land/std@v0.42.0/testing/asserts.ts"
 
 import reduce from '../lib/reduce.ts';
 

--- a/test/reverse_test.ts
+++ b/test/reverse_test.ts
@@ -1,4 +1,4 @@
-import { assertEquals } from "https://deno.land/std@v0.33.0/testing/asserts.ts"
+import { assertEquals } from "https://deno.land/std@v0.42.0/testing/asserts.ts"
 
 import reverse from '../lib/reverse.ts';
 

--- a/test/slice_test.ts
+++ b/test/slice_test.ts
@@ -1,4 +1,4 @@
-import { assertEquals } from "https://deno.land/std@v0.33.0/testing/asserts.ts"
+import { assertEquals } from "https://deno.land/std@v0.42.0/testing/asserts.ts"
 
 import slice from '../lib/slice.ts';
 

--- a/test/sort_test.ts
+++ b/test/sort_test.ts
@@ -1,4 +1,4 @@
-import { assertEquals } from "https://deno.land/std@v0.33.0/testing/asserts.ts"
+import { assertEquals } from "https://deno.land/std@v0.42.0/testing/asserts.ts"
 
 import sort from '../lib/sort.ts';
 

--- a/test/split_test.ts
+++ b/test/split_test.ts
@@ -1,4 +1,4 @@
-import { assertEquals } from "https://deno.land/std@v0.33.0/testing/asserts.ts"
+import { assertEquals } from "https://deno.land/std@v0.42.0/testing/asserts.ts"
 
 import split from '../lib/split.ts';
 

--- a/test/tail_test.ts
+++ b/test/tail_test.ts
@@ -1,4 +1,4 @@
-import { assertEquals } from "https://deno.land/std@v0.33.0/testing/asserts.ts"
+import { assertEquals } from "https://deno.land/std@v0.42.0/testing/asserts.ts"
 
 import tail from '../lib/tail.ts';
 

--- a/test/values_test.ts
+++ b/test/values_test.ts
@@ -1,4 +1,4 @@
-import { assertEquals } from "https://deno.land/std@v0.33.0/testing/asserts.ts"
+import { assertEquals } from "https://deno.land/std@v0.42.0/testing/asserts.ts"
 
 import values from '../lib/values.ts';
 


### PR DESCRIPTION
Hi there, I found a few issues when trying to use this library with the latest version of Deno.
- Use Deno.customInspect instead of Deno.symbols.customInspect.
- Bump assert lib to v0.42.0.